### PR TITLE
Small updates to QRRHO

### DIFF
--- a/pymatgen/analysis/tests/test_quasirrho.py
+++ b/pymatgen/analysis/tests/test_quasirrho.py
@@ -59,9 +59,8 @@ class TestQuasiRRHO(PymatgenTest):
         Test manual input creation. Values from GaussianOutput
         """
         rrho_in = {}
-        rrho_in["mult"] = self.gout.spin_multiplicity
-        rrho_in["elec_energy"] = self.gout.final_energy
-        rrho_in["mol"] = self.gout.final_structure
+        rrho_in["final_energy"] = self.gout.final_energy
+        rrho_in["optimized_molecule"] = self.gout.final_structure.as_dict()
         vib_freqs = [f["frequency"] for f in self.gout.frequencies[-1]]
         rrho_in["frequencies"] = vib_freqs
 


### PR DESCRIPTION
Small updates to `QuasiRRHO` class I made in my recent testing using Q-Chem output files. My changes to the `dict` input keys were motivated by trying to synchronize them with the values in Q-Chem task documents.

Other than linting and small changes due to updating pymatgen, I exposed `h_corrected` as a class attribute so it can be accessed in the output.